### PR TITLE
mediatek: TP-Link Archer AX80v1: add OpenWrt U-Boot (UBI) layout

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -653,6 +653,18 @@ define U-Boot/mt7986_netcore_n60-pro
   DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ddr4
 endef
 
+define U-Boot/mt7986_tplink_archer-ax80-v1-ubi
+  NAME:=TP-Link Archer AX80 v1
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=tplink_archer-ax80-v1-ubi
+  UBOOT_CONFIG:=mt7986_tplink_archer-ax80-v1-ubi
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7986
+  BL2_DDRTYPE:=ddr3
+  DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ubi-ddr3
+endef
+
 define U-Boot/mt7986_tplink_tl-xdr4288
   NAME:=TP-LINK TL-XDR4288
   BUILD_SUBTARGET:=filogic
@@ -937,6 +949,7 @@ UBOOT_TARGETS := \
 	mt7986_mercusys_mr90x-v1 \
 	mt7986_netcore_n60 \
 	mt7986_netcore_n60-pro \
+	mt7986_tplink_archer-ax80-v1-ubi \
 	mt7986_tplink_tl-xdr4288 \
 	mt7986_tplink_tl-xdr6086 \
 	mt7986_tplink_tl-xdr6088 \

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -653,6 +653,18 @@ define U-Boot/mt7986_netcore_n60-pro
   DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ddr4
 endef
 
+define U-Boot/mt7986_tplink_archer-ax80-v1-ubi
+  NAME:=TP-Link Archer AX80 v1
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=tplink_archer-ax80-v1-ubi
+  UBOOT_CONFIG:=mt7986_tplink_archer-ax80-v1-ubi
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7986
+  BL2_DDRTYPE:=ddr3
+  DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ubi-ddr3
+endef
+
 define U-Boot/mt7986_tplink_tl-xdr4288
   NAME:=TP-LINK TL-XDR4288
   BUILD_SUBTARGET:=filogic
@@ -937,6 +949,7 @@ UBOOT_TARGETS := \
 	mt7986_mercusys_mr90x-v1 \
 	mt7986_netcore_n60 \
 	mt7986_netcore_n60-pro \
+  mt7986_tplink_archer-ax80-v1-ubi \
 	mt7986_tplink_tl-xdr4288 \
 	mt7986_tplink_tl-xdr6086 \
 	mt7986_tplink_tl-xdr6088 \

--- a/package/boot/uboot-mediatek/patches/464-add-tplink-archer-ax80-v1.patch
+++ b/package/boot/uboot-mediatek/patches/464-add-tplink-archer-ax80-v1.patch
@@ -1,0 +1,394 @@
+--- /dev/null
++++ b/configs/mt7986_tplink_archer-ax80-v1-ubi_defconfig
+@@ -0,0 +1,120 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7986a-tplink_archer-ax80-v1-ubi"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7986=y
++CONFIG_PRE_CON_BUF_ADDR=0x4007ef00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7986a-tplink_archer-ax80-v1-ubi.dtb"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="mt7986> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_DEFAULT_ENV_FILE="tplink_archer-ax80-v1-ubi_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_DM_I2C=y
++CONFIG_SYS_I2C_MTK=y
++CONFIG_DM_I2C_GPIO=y
++CONFIG_I2C_MUX=y
++CONFIG_I2C_MUX_GPIO=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PCIE_MEDIATEK=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7622=y
++CONFIG_PINCTRL_MT7986=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_PWM=y
++CONFIG_PWM_MTK=y
++CONFIG_RAM=y
++CONFIG_SCSI=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_MTK=y
++CONFIG_USB_STORAGE=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
++CONFIG_LMB_MAX_REGIONS=64
+--- /dev/null
++++ b/arch/arm/dts/mt7986a-tplink_archer-ax80-v1-ubi.dts
+@@ -0,0 +1,196 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2025
++ * Author: Sergey Shlukov <ichizakurain@gmail.com>
++ */
++
++/dts-v1/;
++#include "mt7986.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "TP-Link Archer AX80 v1";
++	compatible = "mediatek,mt7986", "mediatek,mt7986-rfb";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	reg_3p3v: regulator-3p3v {
++		compatible = "regulator-fixed";
++		regulator-name = "fixed-3.3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	reg_5v: regulator-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "fixed-5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	i2c0: i2c@11008000 {
++		compatible = "mediatek,mt7986-i2c";
++		reg = <0x11008000 0x90>,
++			<0x10217080 0x80>;
++		interrupts = <GIC_SPI 136 IRQ_TYPE_LEVEL_HIGH>;
++		clock-div = <16>;
++		clocks = <&infracfg CLK_INFRA_I2C0_CK>,
++			<&infracfg CLK_INFRA_AP_DMA_CK>;
++		clock-names = "main", "dma";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&i2c_pins>;
++		status = "okay";
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>;
++	status = "disabled";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_00>;
++		};
++
++		conf-pd {
++			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
++		};
++	};
++
++	spic_pins: spi1-pins-func-1 {
++		mux {
++			function = "spi";
++			groups = "spi1_2";
++		};
++	};
++
++	uart1_pins: spi1-pins-func-3 {
++		mux {
++			function = "uart";
++			groups = "uart1_2";
++		};
++	};
++
++	pwm_pins: pwm0-pins-func-1 {
++		mux {
++			function = "pwm";
++			groups = "pwm0";
++		};
++	};
++
++	i2c_pins: i2c-pins-3-4 {
++		mux {
++			function = "i2c";
++			groups = "i2c";
++		};
++	};
++};
++
++&pwm {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm_pins>;
++	status = "okay";
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <1>;
++	sample_sel = <0>;
++
++	spi_nand@1 {
++		compatible = "spi-nand";
++		reg = <1>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				reg = <0x0 0x100000>;
++				label = "bl2";
++			};
++
++			partition@100000 {
++				reg = <0x100000 0x100000>;
++				label = "factory";
++			};
++
++			partition@200000 {
++				reg = <0x200000 0x7e00000>;
++				label = "ubi";
++			};
++		};
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/tplink_archer-ax80-v1-ubi_env
+@@ -0,0 +1,69 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootargs=console=ttyS0,115200n8 console_msg_format=syslog
++bootcmd=run led_red_static ; run check_buttons ; run boot_production ; run boot_recovery
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-tplink_archer-ax80-v1-ubi-initramfs-recovery.bin
++bootfile_bl2=openwrt-mediatek-filogic-tplink_archer-ax80-v1-ubi-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-tplink_archer-ax80-v1-ubi-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-tplink_archer-ax80-v1-ubi-squashfs-sysupgrade.itb
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=2
++bootmenu_title=<<< OpenWrt Recovery Menu >>>
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run led_green_blink; run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=noboot=1 ; replacevol=1 ; run boot_tftp_production ; noboot= ; replacevol= ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=noboot=1 ; replacevol=1 ; run boot_tftp_recovery ; noboot= ; replacevol= ; run bootmenu_confirm_return
++bootmenu_6=Load BL31+U-Boot FIP via TFTP then write to NAND.=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=Load BL2 preloader via TFTP then write to NAND.=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_default=run bootcmd ; run boot_recovery ; replacevol=1 ; run boot_tftp_forever
++boot_production=run ubi_read_production && bootm $loadaddr#$bootconf || run led_red_static
++boot_recovery=run ubi_read_recovery && bootm $loadaddr#$bootconf || run led_red_static
++boot_tftp=run led_tftp_start ; tftpboot $loadaddr $bootfile && run led_tftp_success && bootm $loadaddr#$bootconf || run led_tftp_fail
++boot_tftp_forever=while true ; do run boot_tftp ; sleep 1 ; done
++boot_tftp_production=run led_tftp_start ; tftpboot $loadaddr $bootfile_upg && test $replacevol = 1 && iminfo $loadaddr && run ubi_write_production ; if test $noboot = 1 ; then run led_tftp_success ; else run led_tftp_success && bootm $loadaddr#$bootconf ; fi || run led_tftp_fail
++boot_tftp_recovery=run led_tftp_start ; tftpboot $loadaddr $bootfile && test $replacevol = 1 && iminfo $loadaddr && run ubi_write_recovery ; if test $noboot = 1 ; then run led_tftp_success ; else run led_tftp_success && bootm $loadaddr#$bootconf ; fi || run led_tftp_fail
++boot_tftp_write_fip=run led_tftp_start ; tftpboot $loadaddr $bootfile_fip && run ubi_write_fip && run reset_factory || run led_tftp_fail
++boot_tftp_write_bl2=run led_tftp_start ; tftpboot $loadaddr $bootfile_bl2 && run snand_write_bl2 || run led_tftp_fail
++check_buttons=if button reset ; then run boot_tftp ; fi
++ethaddr_factory=mtd read factory 0x40080000 0x0 0x20000 && env readmem -b ethaddr 0x40088000 0x6
++reset_factory=mw $loadaddr 0xff 0x1f000 ; ubi write $loadaddr ubootenv 0x1f000 ; ubi write $loadaddr ubootenv2 0x1f000 ; ubi remove rootfs_data
++snand_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr 0x0 0x40000
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_fip=run ubi_remove_rootfs ; ubi check fip && ubi remove fip ; ubi create fip $filesize static && ubi write $loadaddr fip $filesize
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=run ubi_create_env ; saveenv ; saveenv
++_firstboot=run ethaddr_factory ; run _switch_to_menu ; run _init_env ; bootmenu
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 2 ; setenv bootmenu_delay 2 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title"
++led_addr=0x32
++led_bus=0
++led_enable=0x40
++led_misc=0x5b
++led_pwm_red=0x1c
++led_pwm_green=0x19
++led_pwm_blue=0x16
++led_curr_red=0x2c
++led_curr_green=0x29
++led_curr_blue=0x26
++led_off=i2c dev $led_bus ; for reg in 0x16 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e ; do i2c mw $led_addr $reg 0x00 1 ; done ; i2c mw $led_addr 0x00 0x00 1 ; i2c mw $led_addr 0x01 0x00 1 ; i2c mw $led_addr 0x36 0x00 1
++led_red_static=i2c dev $led_bus ; i2c mw $led_addr 0x00 $led_enable 1 ; i2c mw $led_addr 0x36 $led_misc 1 ; i2c mw $led_addr $led_curr_red 0x14 1 ; i2c mw $led_addr $led_pwm_red 0xff 1 ; i2c mw $led_addr $led_pwm_green 0x00 1 ; i2c mw $led_addr $led_pwm_blue 0x00 1
++led_green_static=run led_off ; i2c dev $led_bus ; i2c mw $led_addr 0x00 $led_enable 1 ; i2c mw $led_addr 0x36 $led_misc 1 ; i2c mw $led_addr $led_curr_green 0x14 1 ; i2c mw $led_addr $led_pwm_red 0x00 1 ; i2c mw $led_addr $led_pwm_green 0xff 1 ; i2c mw $led_addr $led_pwm_blue 0x00 1
++led_green_blink=for i in 1 2 3 4 5; do run led_green_static; sleep 1; run led_off; sleep 1; done
++led_tftp_start=run led_off ; while true; do run led_green_static; sleep 0.5; run led_off; sleep 0.5; if test -n "$tftp_active"; then break; fi; done
++led_tftp_success=setenv tftp_active 1; run led_green_static
++led_tftp_fail=setenv tftp_active 1; run led_red_static

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -36,6 +36,7 @@ nokia,ea0326gmp|\
 qihoo,360t7|\
 routerich,ax3000-ubootmod|\
 snr,snr-cpe-ax2|\
+tplink,archer-ax80-v1-ubi|\
 tplink,tl-xdr4288|\
 tplink,tl-xdr6086|\
 tplink,tl-xdr6088|\

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-common.dtsi
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: (GL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+    aliases: aliases {
+        led-boot = &led_B;
+        led-failsafe = &led_R;
+        led-running = &led_B;
+        led-upgrade = &led_G;
+        serial0 = &uart0;
+    };
+
+    chosen: chosen {
+        stdout-path = "serial0:115200n8";
+    };
+
+    memory {
+        reg = <0 0x40000000 0 0x20000000>;
+    };
+
+    gpio-keys {
+        compatible = "gpio-keys";
+
+        button-reset {
+            label = "reset";
+            linux,code = <KEY_RESTART>;
+            gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+        };
+
+        button-ledswitch {
+            label = "ledswitch";
+            linux,code = <KEY_BRIGHTNESS_ZERO>;
+            gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+        };
+
+        button-wps {
+            label = "wps";
+            linux,code = <KEY_WPS_BUTTON>;
+            gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+        };
+
+        button-wifi {
+            label = "wlan";
+            linux,code = <KEY_WLAN>;
+            gpios = <&pio 16 GPIO_ACTIVE_LOW>;
+        };
+    };
+
+    reg_1p8v: regulator-1p8v {
+        compatible = "regulator-fixed";
+        regulator-name = "fixed-1.8V";
+        regulator-min-microvolt = <1800000>;
+        regulator-max-microvolt = <1800000>;
+        regulator-boot-on;
+        regulator-always-on;
+    };
+
+    reg_3p3v: regulator-3p3v {
+        compatible = "regulator-fixed";
+        regulator-name = "fixed-3.3V";
+        regulator-min-microvolt = <3300000>;
+        regulator-max-microvolt = <3300000>;
+        regulator-boot-on;
+        regulator-always-on;
+    };
+
+    reg_5v: regulator-5v {
+        compatible = "regulator-fixed";
+        regulator-name = "fixed-5V";
+        regulator-min-microvolt = <5000000>;
+        regulator-max-microvolt = <5000000>;
+        regulator-boot-on;
+        regulator-always-on;
+    };
+};
+
+&auxadc {
+    status = "okay";
+};
+
+&crypto {
+    status = "okay";
+};
+
+&eth {
+    status = "okay";
+
+    gmac0: mac@0 {
+        compatible = "mediatek,eth-mac";
+        reg = <0>;
+        phy-mode = "2500base-x";
+        fixed-link {
+            speed = <2500>;
+            full-duplex;
+        };
+    };
+
+    gmac1: mac@1 {
+        compatible = "mediatek,eth-mac";
+        reg = <1>;
+        phy-mode = "2500base-x";
+        phy-handle = <&phy6>;
+    };
+
+    mdio: mdio-bus {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+        reset-delay-us = <1500000>;
+        reset-post-delay-us = <1000000>;
+
+        phy6: phy@6 {
+            compatible = "ethernet-phy-ieee802.3-c45";
+            reg = <6>;
+        };
+
+        switch@1f {
+            compatible = "mediatek,mt7531";
+            reg = <31>;
+            reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+            interrupt-controller;
+            #interrupt-cells = <1>;
+            interrupt-parent = <&pio>;
+            interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+            ports {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                port@0 {
+                    reg = <0>;
+                    label = "lan0";
+                };
+                port@1 {
+                    reg = <1>;
+                    label = "lan1";
+                };
+                port@2 {
+                    reg = <2>;
+                    label = "lan2";
+                };
+                port@3 {
+                    reg = <3>;
+                    label = "lan3";
+                };
+                port@6 {
+                    reg = <6>;
+                    label = "cpu";
+                    ethernet = <&gmac0>;
+                    phy-mode = "2500base-x";
+                    fixed-link {
+                        speed = <2500>;
+                        full-duplex;
+                    };
+                };
+            };
+        };
+    };
+};
+
+&i2c0 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    status = "okay";
+
+    lp55231: led-controller@32 {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        compatible = "ti,lp55231";
+        reg = <0x32>;
+        status = "okay";
+        clock-mode = /bits/ 8 <1>;
+
+        led_B: led@0 {
+            chan-name = "B";
+            led-cur = /bits/ 8 <0x14>;
+            max-cur = /bits/ 8 <0x20>;
+            reg = <0>;
+            color = <LED_COLOR_ID_BLUE>;
+        };
+
+        led_G: led@3 {
+            chan-name = "G";
+            led-cur = /bits/ 8 <0x14>;
+            max-cur = /bits/ 8 <0x20>;
+            reg = <3>;
+            color = <LED_COLOR_ID_GREEN>;
+        };
+
+        led_R: led@6 {
+            chan-name = "R";
+            led-cur = /bits/ 8 <0x14>;
+            max-cur = /bits/ 8 <0x20>;
+            reg = <6>;
+            color = <LED_COLOR_ID_RED>;
+        };
+    };
+};
+
+&spi0 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&spi_flash_pins>;
+    status = "okay";
+
+    spi_nand_flash: flash@0 {
+        compatible = "spi-nand";
+        reg = <0>;
+
+        spi-max-frequency = <52000000>;
+        spi-tx-bus-width = <4>;
+        spi-rx-bus-width = <4>;
+
+        spi-cal-enable;
+        spi-cal-mode = "read-data";
+        spi-cal-datalen = <7>;
+        spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+        spi-cal-addrlen = <5>;
+        spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+        partitions: partitions {
+            compatible = "fixed-partitions";
+            #address-cells = <1>;
+            #size-cells = <1>;
+        };
+    };
+};
+
+&pio {
+    spi_flash_pins: spi-flash-pins-33-to-38 {
+        mux {
+            function = "spi";
+            groups = "spi0", "spi0_wp_hold";
+        };
+        conf-pu {
+            pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+            drive-strength = <4>;
+            mediatek,pull-up-adv = <0>;
+        };
+        conf-pd {
+            pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+            drive-strength = <4>;
+            mediatek,pull-down-adv = <0>;
+        };
+    };
+    wf_2g_5g_pins: wf_2g_5g-pins {
+        mux {
+            function = "wifi";
+            groups = "wf_2g", "wf_5g";
+        };
+        conf {
+            pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+            "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+            "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+            "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+            "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+            "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+            "WF1_TOP_CLK", "WF1_TOP_DATA";
+            drive-strength = <4>;
+        };
+    };
+};
+
+&trng {
+    status = "okay";
+};
+
+&uart0 {
+    status = "okay";
+};
+
+&ssusb {
+    vusb33-supply = <&reg_3p3v>;
+    vbus-supply = <&reg_5v>;
+    status = "okay";
+};
+
+&usb_phy {
+    status = "okay";
+};
+
+&watchdog {
+    status = "okay";
+};
+
+&wifi {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&wf_2g_5g_pins>;
+};

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-common.dtsi
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: (GL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	aliases: aliases {
+		led-boot = &led_B;
+		led-failsafe = &led_R;
+		led-running = &led_B;
+		led-upgrade = &led_G;
+		serial0 = &uart0;
+	};
+	
+	chosen: chosen {
+		stdout-path = "serial0:115200n8";
+	};
+	
+	memory {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+	
+	gpio-keys {
+		compatible = "gpio-keys";
+		
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+		
+		button-ledswitch {
+			label = "ledswitch";
+			linux,code = <KEY_BRIGHTNESS_ZERO>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+		
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+		
+		button-wifi {
+			label = "wlan";
+			linux,code = <KEY_WLAN>;
+			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+	
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+	
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&auxadc {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+	
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+		};
+	};
+	
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+	};
+	
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <1500000>;
+		reset-post-delay-us = <1000000>;
+		
+		phy6: phy@6 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <6>;
+		};
+		
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+			
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					label = "lan0";
+				};
+				port@1 {
+					reg = <1>;
+					label = "lan1";
+				};
+				port@2 {
+					reg = <2>;
+					label = "lan2";
+				};
+				port@3 {
+					reg = <3>;
+					label = "lan3";
+				};
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+					};
+				};
+			};
+		};
+	};
+};
+
+&i2c0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+	
+	lp55231: led-controller@32 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,lp55231";
+		reg = <0x32>;
+		status = "okay";
+		clock-mode = /bits/ 8 <1>;
+		
+		led_B: led@0 {
+			chan-name = "B";
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			reg = <0>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+		
+		led_G: led@3 {
+			chan-name = "G";
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			reg = <3>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+		
+		led_R: led@6 {
+			chan-name = "R";
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			reg = <6>;
+			color = <LED_COLOR_ID_RED>;
+		};
+	};
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+	
+	spi_nand_flash: flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+		
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <4>;
+			mediatek,pull-up-adv = <0>;
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <4>;
+			mediatek,pull-down-adv = <0>;
+		};
+	};
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+};

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-ubi.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-ubi.dts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: (GL-2.0 OR MIT)
+
+#include "mt7986a-tplink-archer-ax80-v1-common.dtsi"
+
+/ {
+	compatible = "tplink,archer-ax80-v1-ubi", "mediatek,mt7986a";
+	model = "TP-Link Archer AX80V1 (UBI)";
+};
+
+&aliases {
+	label-mac-device = &gmac0;
+};
+
+&chosen {
+	bootargs-append = " root=/dev/fit0 rootwait";
+	rootdisk = <&ubi_fit>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_8000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_8000 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&partitions {
+	partition@0 {
+		label = "boot";
+		reg = <0x0 0x200000>;
+		read-only;
+		
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		
+		partition@0 {
+			label = "bl2";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+		
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x100000>;
+			read-only;
+			
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x1000>;
+				};
+				
+				macaddr_factory_8000: macaddr@8000 {
+					compatible = "mac-base";
+					reg = <0x8000 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+	};
+	
+	partition@200000 {
+		compatible = "linux,ubi";
+		reg = <0x200000 0x7e00000>;
+		label = "ubi";
+		
+		volumes {
+			ubi_fit: ubi-volume-fit {
+				volname = "fit";
+			};
+			
+			ubi_ubootenv: ubi-volume-ubootenv {
+				volname = "ubootenv";
+			};
+			
+			ubi_ubootenv2: ubi-volume-ubootenv2 {
+				volname = "ubootenv2";
+			};
+		};
+	};
+};
+
+&ubi_ubootenv {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&ubi_ubootenv2 {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool";
+	};
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_8000 0>;
+		nvmem-cell-names = "mac-address";
+	};
+	
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_8000 (-1)>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-ubi.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1-ubi.dts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: (GL-2.0 OR MIT)
+
+#include "mt7986a-tplink-archer-ax80-v1-common.dtsi"
+
+/ {
+    compatible = "tplink,archer-ax80-v1-ubi", "mediatek,mt7986a";
+    model = "TP-Link Archer AX80V1 (UBI)";
+};
+
+&aliases {
+    label-mac-device = &gmac0;
+};
+
+&chosen {
+    bootargs-append = " root=/dev/fit0 rootwait";
+    rootdisk = <&ubi_fit>;
+};
+
+&gmac0 {
+    nvmem-cells = <&macaddr_factory_8000 0>;
+    nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+    nvmem-cells = <&macaddr_factory_8000 1>;
+    nvmem-cell-names = "mac-address";
+};
+
+&partitions {
+    partition@0 {
+        label = "boot";
+        reg = <0x0 0x200000>;
+        read-only;
+
+        compatible = "fixed-partitions";
+        #address-cells = <1>;
+        #size-cells = <1>;
+
+        partition@0 {
+            label = "bl2";
+            reg = <0x0 0x100000>;
+            read-only;
+        };
+
+        partition@100000 {
+            label = "factory";
+            reg = <0x100000 0x100000>;
+            read-only;
+
+            nvmem-layout {
+                compatible = "fixed-layout";
+                #address-cells = <1>;
+                #size-cells = <1>;
+
+                eeprom_factory_0: eeprom@0 {
+                    reg = <0x0 0x1000>;
+                };
+
+                macaddr_factory_8000: macaddr@8000 {
+                    compatible = "mac-base";
+                    reg = <0x8000 0x6>;
+                    #nvmem-cell-cells = <1>;
+                };
+            };
+        };
+    };
+
+    partition@200000 {
+        compatible = "linux,ubi";
+        reg = <0x200000 0x7e00000>;
+        label = "ubi";
+
+        volumes {
+            ubi_fit: ubi-volume-fit {
+                volname = "fit";
+            };
+
+            ubi_ubootenv: ubi-volume-ubootenv {
+                volname = "ubootenv";
+            };
+
+            ubi_ubootenv2: ubi-volume-ubootenv2 {
+                volname = "ubootenv2";
+            };
+        };
+    };
+};
+
+&ubi_ubootenv {
+    nvmem-layout {
+        compatible = "u-boot,env-redundant-bool";
+    };
+};
+
+&ubi_ubootenv2 {
+    nvmem-layout {
+        compatible = "u-boot,env-redundant-bool";
+    };
+};
+
+&wifi {
+    nvmem-cells = <&eeprom_factory_0>;
+    nvmem-cell-names = "eeprom";
+
+    band@0 {
+        reg = <0>;
+        nvmem-cells = <&macaddr_factory_8000 0>;
+        nvmem-cell-names = "mac-address";
+    };
+
+    band@1 {
+        reg = <1>;
+        nvmem-cells = <&macaddr_factory_8000 (-1)>;
+        nvmem-cell-names = "mac-address";
+    };
+};

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
@@ -1,332 +1,46 @@
-// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// SPDX-License-Identifier: (GL-2.0 OR MIT)
 
-/dts-v1/;
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
-
-#include "mt7986a.dtsi"
+#include "mt7986a-tplink-archer-ax80-v1-common.dtsi"
 
 / {
 	compatible = "tplink,archer-ax80-v1", "mediatek,mt7986a";
 	model = "TP-Link Archer AX80V1";
-
-	aliases {
-		serial0 = &uart0;
-		led-boot = &led_B;
-		led-failsafe = &led_R;
-		led-running = &led_B;
-		led-upgrade = &led_G;
-	};
-
-	chosen {
-		stdout-path = "serial0:115200n8";
-	};
-
-	memory@40000000 {
-		reg = <0 0x40000000 0 0x20000000>;
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		button-reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
-		};
-
-		button-ledswitch {
-			label = "ledswitch";
-			linux,code = <KEY_BRIGHTNESS_ZERO>;
-			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
-		};
-
-		button-wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
-		};
-
-		button-wifi {
-			label = "wlan";
-			linux,code = <KEY_WLAN>;
-			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	reg_1p8v: regulator-1p8v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-1.8V";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
-
-	reg_5v: regulator-5v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-5V";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
 };
 
-&auxadc {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
-&eth {
-	status = "okay";
-
-	gmac0: mac@0 {
-		compatible = "mediatek,eth-mac";
-		reg = <0>;
-		phy-mode = "2500base-x";
-		fixed-link {
-			speed = <2500>;
-			full-duplex;
-		};
+&partitions {
+	partition@0 {
+		label = "boot";
+		reg = <0x0 0x200000>;
+		read-only;
 	};
-
-	gmac1: mac@1 {
-		compatible = "mediatek,eth-mac";
-		reg = <1>;
-		phy-mode = "2500base-x";
-		phy-handle = <&phy6>;
+	
+	partition@200000 {
+		label = "u-boot-env";
+		reg = <0x200000 0x100000>;
 	};
-
-	mdio: mdio-bus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
-		reset-delay-us = <1500000>;
-		reset-post-delay-us = <1000000>;
-
-		phy6: phy@6 {
-			compatible = "ethernet-phy-ieee802.3-c45";
-			reg = <6>;
-		};
-
-		switch@1f {
-			compatible = "mediatek,mt7531";
-			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
-			interrupt-controller;
-			#interrupt-cells = <1>;
-			interrupt-parent = <&pio>;
-			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
-
-			ports {
-				#address-cells = <1>;
-				#size-cells = <0>;
-				port@0 {
-					reg = <0>;
-					label = "lan0";
-				};
-				port@1 {
-					reg = <1>;
-					label = "lan1";
-				};
-				port@2 {
-					reg = <2>;
-					label = "lan2";
-				};
-				port@3 {
-					reg = <3>;
-					label = "lan3";
-				};
-				port@6 {
-					reg = <6>;
-					label = "cpu";
-					ethernet = <&gmac0>;
-					phy-mode = "2500base-x";
-					fixed-link {
-						speed = <2500>;
-						full-duplex;
-					};
-				};
-			};
-		};
+	
+	partition@300000 {
+		label = "ubi0";
+		reg = <0x300000 0x3200000>;
 	};
-};
-
-&i2c0 {
-	status = "okay";
-
-	lp55231: led-controller@32 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "ti,lp55231";
-		reg = <0x32>;
-		status = "okay";
-		clock-mode = /bits/ 8 <1>;
-
-		led_B: led@0 {
-			chan-name = "B";
-			led-cur = /bits/ 8 <0x14>;
-			max-cur = /bits/ 8 <0x20>;
-			reg = <0>;
-			color = <LED_COLOR_ID_BLUE>;
-		};
-
-		led_G: led@3 {
-			chan-name = "G";
-			led-cur = /bits/ 8 <0x14>;
-			max-cur = /bits/ 8 <0x20>;
-			reg = <3>;
-			color = <LED_COLOR_ID_GREEN>;
-		};
-
-		led_R: led@6 {
-			chan-name = "R";
-			led-cur = /bits/ 8 <0x14>;
-			max-cur = /bits/ 8 <0x20>;
-			reg = <6>;
-			color = <LED_COLOR_ID_RED>;
-		};
-
+	
+	partition@3500000 {
+		label = "ubi1";
+		reg = <0x3500000 0x3200000>;
 	};
-};
-&spi0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi_flash_pins>;
-	status = "okay";
-
-	spi_nand_flash: flash@0 {
-		compatible = "spi-nand";
-		reg = <0>;
-
-		spi-max-frequency = <52000000>;
-		spi-tx-bus-width = <4>;
-		spi-rx-bus-width = <4>;
-
-		spi-cal-enable;
-		spi-cal-mode = "read-data";
-		spi-cal-datalen = <7>;
-		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
-		spi-cal-addrlen = <5>;
-		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
-
-		partitions: partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "boot";
-				reg = <0x0 0x200000>;
-				read-only;
-			};
-
-			partition@200000 {
-				label = "u-boot-env";
-				reg = <0x200000 0x100000>;
-			};
-
-			partition@300000 {
-				label = "ubi0";
-				reg = <0x300000 0x3200000>;
-			};
-
-			partition@3500000 {
-				label = "ubi1";
-				reg = <0x3500000 0x3200000>;
-			};
-
-			partition@6700000 {
-				label = "userconfig";
-				reg = <0x6700000 0x800000>;
-			};
-
-			factory:partition@6f00000 {
-				label = "tp_data";
-				reg = <0x6f00000 0x400000>;
-			};
-
-			partition@7300000 {
-				label = "mali_data";
-				reg = <0x7300000 0x800000>;
-			};
-		};
+	
+	partition@6700000 {
+		label = "userconfig";
+		reg = <0x6700000 0x800000>;
 	};
-};
-
-&pio {
-	spi_flash_pins: spi-flash-pins-33-to-38 {
-		mux {
-			function = "spi";
-			groups = "spi0", "spi0_wp_hold";
-		};
-		conf-pu {
-			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
-			drive-strength = <8>;
-			mediatek,pull-up-adv = <0>; /* bias-disable */
-		};
-		conf-pd {
-			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
-			drive-strength = <8>;
-			mediatek,pull-down-adv = <0>; /* bias-disable */
-		};
+	
+	factory:partition@6f00000 {
+		label = "tp_data";
+		reg = <0x6f00000 0x400000>;
 	};
-	wf_2g_5g_pins: wf_2g_5g-pins {
-		mux {
-			function = "wifi";
-			groups = "wf_2g", "wf_5g";
-		};
-		conf {
-			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
-			"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
-			"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
-			"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
-			"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
-			"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
-			"WF1_TOP_CLK", "WF1_TOP_DATA";
-			drive-strength = <4>;
-		};
+	
+	partition@7300000 {
+		label = "mali_data";
+		reg = <0x7300000 0x800000>;
 	};
-};
-
-&trng {
-	status = "okay";
-};
-
-&uart0 {
-	status = "okay";
-};
-
-&ssusb {
-	vusb33-supply = <&reg_3p3v>;
-	vbus-supply = <&reg_5v>;
-	status = "okay";
-};
-
-&usb_phy {
-	status = "okay";
-};
-
-&watchdog {
-	status = "okay";
-};
-
-&wifi {
-	status = "okay";
-	pinctrl-names = "default";
-	pinctrl-0 = <&wf_2g_5g_pins>;
 };

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
@@ -1,332 +1,46 @@
-// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// SPDX-License-Identifier: (GL-2.0 OR MIT)
 
-/dts-v1/;
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "mt7986a-tplink-archer-ax80-v1-common.dtsi"
 
-#include "mt7986a.dtsi"
-
-/ {
-	compatible = "tplink,archer-ax80-v1", "mediatek,mt7986a";
-	model = "TP-Link Archer AX80V1";
-
-	aliases {
-		serial0 = &uart0;
-		led-boot = &led_B;
-		led-failsafe = &led_R;
-		led-running = &led_B;
-		led-upgrade = &led_G;
-	};
-
-	chosen {
-		stdout-path = "serial0:115200n8";
-	};
-
-	memory@40000000 {
-		reg = <0 0x40000000 0 0x20000000>;
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		button-reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
-		};
-
-		button-ledswitch {
-			label = "ledswitch";
-			linux,code = <KEY_BRIGHTNESS_ZERO>;
-			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
-		};
-
-		button-wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
-		};
-
-		button-wifi {
-			label = "wlan";
-			linux,code = <KEY_WLAN>;
-			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	reg_1p8v: regulator-1p8v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-1.8V";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
-
-	reg_5v: regulator-5v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-5V";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
+ / {
+    compatible = "tplink,archer-ax80-v1", "mediatek,mt7986a";
+    model = "TP-Link Archer AX80V1";
 };
 
-&auxadc {
-	status = "okay";
-};
+&partitions {
+    partition@0 {
+        label = "boot";
+        reg = <0x0 0x200000>;
+        read-only;
+    };
 
-&crypto {
-	status = "okay";
-};
+    partition@200000 {
+        label = "u-boot-env";
+        reg = <0x200000 0x100000>;
+    };
 
-&eth {
-	status = "okay";
+    partition@300000 {
+        label = "ubi0";
+        reg = <0x300000 0x3200000>;
+    };
 
-	gmac0: mac@0 {
-		compatible = "mediatek,eth-mac";
-		reg = <0>;
-		phy-mode = "2500base-x";
-		fixed-link {
-			speed = <2500>;
-			full-duplex;
-		};
-	};
+    partition@3500000 {
+        label = "ubi1";
+        reg = <0x3500000 0x3200000>;
+    };
 
-	gmac1: mac@1 {
-		compatible = "mediatek,eth-mac";
-		reg = <1>;
-		phy-mode = "2500base-x";
-		phy-handle = <&phy6>;
-	};
+    partition@6700000 {
+        label = "userconfig";
+        reg = <0x6700000 0x800000>;
+    };
 
-	mdio: mdio-bus {
-		#address-cells = <1>;
-		#size-cells = <0>;
+    factory:partition@6f00000 {
+        label = "tp_data";
+        reg = <0x6f00000 0x400000>;
+    };
 
-		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
-		reset-delay-us = <1500000>;
-		reset-post-delay-us = <1000000>;
-
-		phy6: phy@6 {
-			compatible = "ethernet-phy-ieee802.3-c45";
-			reg = <6>;
-		};
-
-		switch@1f {
-			compatible = "mediatek,mt7531";
-			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
-			interrupt-controller;
-			#interrupt-cells = <1>;
-			interrupt-parent = <&pio>;
-			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
-
-			ports {
-				#address-cells = <1>;
-				#size-cells = <0>;
-				port@0 {
-					reg = <0>;
-					label = "lan0";
-				};
-				port@1 {
-					reg = <1>;
-					label = "lan1";
-				};
-				port@2 {
-					reg = <2>;
-					label = "lan2";
-				};
-				port@3 {
-					reg = <3>;
-					label = "lan3";
-				};
-				port@6 {
-					reg = <6>;
-					label = "cpu";
-					ethernet = <&gmac0>;
-					phy-mode = "2500base-x";
-					fixed-link {
-						speed = <2500>;
-						full-duplex;
-					};
-				};
-			};
-		};
-	};
-};
-
-&i2c0 {
-	status = "okay";
-
-	lp55231: led-controller@32 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "ti,lp55231";
-		reg = <0x32>;
-		status = "okay";
-		clock-mode = /bits/ 8 <1>;
-
-		led_B: led@0 {
-			chan-name = "B";
-			led-cur = /bits/ 8 <0x14>;
-			max-cur = /bits/ 8 <0x20>;
-			reg = <0>;
-			color = <LED_COLOR_ID_BLUE>;
-		};
-
-		led_G: led@3 {
-			chan-name = "G";
-			led-cur = /bits/ 8 <0x14>;
-			max-cur = /bits/ 8 <0x20>;
-			reg = <3>;
-			color = <LED_COLOR_ID_GREEN>;
-		};
-
-		led_R: led@6 {
-			chan-name = "R";
-			led-cur = /bits/ 8 <0x14>;
-			max-cur = /bits/ 8 <0x20>;
-			reg = <6>;
-			color = <LED_COLOR_ID_RED>;
-		};
-
-	};
-};
-&spi0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi_flash_pins>;
-	status = "okay";
-
-	spi_nand_flash: flash@0 {
-		compatible = "spi-nand";
-		reg = <0>;
-
-		spi-max-frequency = <52000000>;
-		spi-tx-bus-width = <4>;
-		spi-rx-bus-width = <4>;
-
-		spi-cal-enable;
-		spi-cal-mode = "read-data";
-		spi-cal-datalen = <7>;
-		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
-		spi-cal-addrlen = <5>;
-		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
-
-		partitions: partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "boot";
-				reg = <0x0 0x200000>;
-				read-only;
-			};
-
-			partition@200000 {
-				label = "u-boot-env";
-				reg = <0x200000 0x100000>;
-			};
-
-			partition@300000 {
-				label = "ubi0";
-				reg = <0x300000 0x3200000>;
-			};
-
-			partition@3500000 {
-				label = "ubi1";
-				reg = <0x3500000 0x3200000>;
-			};
-
-			partition@6700000 {
-				label = "userconfig";
-				reg = <0x6700000 0x800000>;
-			};
-
-			factory:partition@6f00000 {
-				label = "tp_data";
-				reg = <0x6f00000 0x400000>;
-			};
-
-			partition@7300000 {
-				label = "mali_data";
-				reg = <0x7300000 0x800000>;
-			};
-		};
-	};
-};
-
-&pio {
-	spi_flash_pins: spi-flash-pins-33-to-38 {
-		mux {
-			function = "spi";
-			groups = "spi0", "spi0_wp_hold";
-		};
-		conf-pu {
-			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
-			drive-strength = <8>;
-			mediatek,pull-up-adv = <0>; /* bias-disable */
-		};
-		conf-pd {
-			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
-			drive-strength = <8>;
-			mediatek,pull-down-adv = <0>; /* bias-disable */
-		};
-	};
-	wf_2g_5g_pins: wf_2g_5g-pins {
-		mux {
-			function = "wifi";
-			groups = "wf_2g", "wf_5g";
-		};
-		conf {
-			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
-			"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
-			"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
-			"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
-			"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
-			"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
-			"WF1_TOP_CLK", "WF1_TOP_DATA";
-			drive-strength = <4>;
-		};
-	};
-};
-
-&trng {
-	status = "okay";
-};
-
-&uart0 {
-	status = "okay";
-};
-
-&ssusb {
-	vusb33-supply = <&reg_3p3v>;
-	vbus-supply = <&reg_5v>;
-	status = "okay";
-};
-
-&usb_phy {
-	status = "okay";
-};
-
-&watchdog {
-	status = "okay";
-};
-
-&wifi {
-	status = "okay";
-	pinctrl-names = "default";
-	pinctrl-0 = <&wf_2g_5g_pins>;
+    partition@7300000 {
+        label = "mali_data";
+        reg = <0x7300000 0x800000>;
+    };
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -141,7 +141,8 @@ mediatek_setup_interfaces()
 	wavlink,wl-wn586x3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
 		;;
-	tplink,archer-ax80-v1)
+	tplink,archer-ax80-v1|\
+	tplink,archer-ax80-v1-ubi)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
 		;;
 	tplink,re6000xd)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -91,6 +91,7 @@ platform_do_upgrade() {
 	qihoo,360t7|\
 	routerich,ax3000-ubootmod|\
  	snr,snr-cpe-ax2|\
+	tplink,archer-ax80-v1-ubi|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1763,6 +1763,34 @@ define Device/tplink_archer-ax80-v1
 endef
 TARGET_DEVICES += tplink_archer-ax80-v1
 
+define Device/tplink_archer-ax80-v1-ubi
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := Archer AX80V1 (UBI)
+  DEVICE_DTS := mt7986a-tplink-archer-ax80-v1-ubi
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x43f00000
+  DEVICE_PACKAGES := kmod-leds-lp5523 kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.bin
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+    fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
+    pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+    fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
+    append-metadata
+  ARTIFACTS := bl31-uboot.fip preloader.bin
+  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot tplink_archer-ax80-v1-ubi
+  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ubi-ddr3
+endef
+TARGET_DEVICES += tplink_archer-ax80-v1-ubi
+
 define Device/tplink_re6000xd
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := RE6000XD


### PR DESCRIPTION

This commit adds OpenWrt U-Boot (UBI) layout support for TP-Link Archer AX80v1.

1. Installation (UART)

   Place OpenWrt initramfs image on tftp server with IP 192.168.1.2
   Attach UART, switch on the router and interrupt the boot process by pressing 'Ctrl-C'
   Load and run OpenWrt initramfs image:
```
tftpboot ubi-initramfs-recovery.bin
bootm
```
2. Make backups:
```
cat /dev/mtd0 > /tmp/boot.bin
cat /dev/mtd5 > /tmp/tp_data.bin
```
   Copy /tp_data dir content, /tmp/boot.bin and /tmp/tp_data.bin and to
   your PC using scp. You can also backup the remaining partititons. Copy
   backups to a safe place, they are required for the next steps and stock
   firmware recovery.

3. Reboot to OpenWrt initramfs:
```
reboot
```

4. Copy OpenWrt ubi-bl31-uboot.fip, ubi-preloader.bin,
   ubi-squashfs-sysupgrade.itb and MT7986_EEPROM.bin, default-mac (from
   /tp_data backup) to the /tmp folder of the router using scp.

5. Prepare UBI:
```
ubidetach -p /dev/mtd3; ubiformat /dev/mtd3 -y; ubiattach -p /dev/mtd3
ubimkvol /dev/ubi0 -N fip -t static -s 1MiB
ubiupdatevol /dev/ubi0_0 /tmp/ubi-bl31-uboot.fip
ubimkvol /dev/ubi0 -N ubootenv -s 0x1f000
ubimkvol /dev/ubi0 -N ubootenv2 -s 0x1f000
```

6.  Install kmod-mtd-rw and unlock partitions:
```
opkg update && opkg install kmod-mtd-rw
insmod mtd-rw i_want_a_brick=1
mtd unlock boot
mtd unlock bl2
mtd unlock factory
```

7. Prepare "factory" partition:
```
dd if=/dev/zero bs=$((0x8000)) count=1 | tr '\000' '\377' > /tmp/factory.bin
dd if=/tmp/MT7986_EEPROM.bin of=/tmp/factory.bin conv=notrunc
dd if=/tmp/default-mac >> /tmp/factory.bin
```

8. Write "factory" partition:
```
mtd erase factory
mtd write /tmp/factory.bin factory
```

9. Write preloader partition:
```
mtd erase bl2
mtd write /tmp/ubi-preloader.bin bl2
```

10. Write OpenWrt sysupgrade image:
```
sysupgrade -n /tmp/ubi-squashfs-sysupgrade.itb
```

Recovery
--------
1. Place OpenWrt ubi-initramfs-recovery.bin image (with original name) on the
   tftp server (IP: 192.168.1.254).
2. Press "reset" button and power on the router. After ~10 sec release the
   button.
3. Use OpenWrt initramfs system for recovery.

BL2 and FIP recovery
--------------------
Use mtk_uartboot and UART connetion if BL2 or FIP in UBI is destroyed:
Link: https://github.com/981213/mtk_uartboot

Return to stock:
----------------
1. Copy "boot" partition backup (boot.bin) to the /tmp dir of the router
   using scp.

2. Install kmod-mtd-rw:
```
opkg update && opkg install kmod-mtd-rw
```

3. Restore stock U-Boot:
```
   insmod mtd-rw i_want_a_brick=1
   mtd unlock boot
   mtd erase boot
   mtd write /tmp/boot.bin boot
```

4. Erase UBI and reboot:
```
mtd erase ubi
reboot
```

5. Open U-Boot web recovery, upload stock firmware image and start
   upgrade.
Link: http://192.168.1.1/

6. After reboot, upgrade with stock firmware image again via WebUI.

7. Complete steps 1-4 of the Installation (UART).
Link: https://github.com/openwrt/openwrt/pull/17753

8. Upload "tp_data" partition backup (tp_data.bin) to the /tmp folder of
   the router using scp.

9. Restore stock calibrations:
```
mtd write /tmp/tp_data.bin tp_data
reboot
```

10. Perform "factory restore" via stock firmware web interface.

Signed-off-by: Sergey Shlukov <ichizakurain@gmail.com>